### PR TITLE
Add MetaMask neutrality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Lighthouse	|	Eth2 Client Team	|	🟩 Support	|
 Lodestar	|	Eth2 Client Team	|	🟩 Support	|
 Loopring	|	Layer 2	|	🟩 Support	|
 MakerDAO	|	App	|	🟩 Support	|	87% Yes, 11% Abstain, 2% No (53 voters). To be followed by a MKR vote soon, read the discussion here: [Forum Signal Request](https://forum.makerdao.com/t/signal-request-does-makerdao-support-eip-1559/6646).
+MetaMask | Wallet |	🟦 Neutral |
 mStable	|	App	|	🟩 Support	|
 Opium	|	App	|	🟩 Support	|
 Optimism	|	Layer 2	|	🟩 Support	|


### PR DESCRIPTION
Planning to support Ethereum whatever way it goes (we've got designs for 1559, and we're ready to implement them as needed).